### PR TITLE
Fix for current ESPHome version syntax

### DIFF
--- a/components/frekvens_panel/display.py
+++ b/components/frekvens_panel/display.py
@@ -38,7 +38,8 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    await cg.register_component(var, config)
+    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+        await cg.register_component(var, config)
     await display.register_display(var, config)
 
     cg.add(var.set_pins(

--- a/components/frekvens_panel/display.py
+++ b/components/frekvens_panel/display.py
@@ -38,8 +38,8 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
-        await cg.register_component(var, config)
+#    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+ #       await cg.register_component(var, config)
     await display.register_display(var, config)
 
     cg.add(var.set_pins(

--- a/components/frekvens_panel/frekvens-panel.h
+++ b/components/frekvens_panel/frekvens-panel.h
@@ -2,6 +2,8 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/display/display_buffer.h"
+#include "esphome/core/version.h"
+
 
 #include "frekvens-driver.h"
 
@@ -9,8 +11,13 @@
 namespace esphome {
 namespace frekvenspanel {
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 12, 0)
+class Panel : public display::DisplayBuffer {
+#else
+
 class Panel : public PollingComponent,
                 public display::DisplayBuffer {
+#endif 
  public:
   int p_latch;
   int p_clock;


### PR DESCRIPTION
Hi, the current ESPHome version requires different syntax for the display component. To be able to use this script independent from the version, an added library checks the current utilized ESPHome version and the syntax get's adapted to the necessary form. 

I only fixed it for the Ikea Frekvens Panel, due the reason that's the only hardware I can verify my working code with. The procedure for the Obegränsad should be the same.

![photo_2024-04-07_23-54-15](https://github.com/sascha-hemi/esphome-ikea-led-matrix/assets/116027657/a48be619-610c-4acf-b79d-c3e720e868d2)
